### PR TITLE
Change iteritems to items for changes made in python 3

### DIFF
--- a/filter_plugins/to_ini.py
+++ b/filter_plugins/to_ini.py
@@ -5,9 +5,9 @@ def to_ini(databases = []):
     """
     s = ''
     for db in databases:
-        for alias, config in db.iteritems():
+        for alias, config in db.items():
             s = s + str(alias) + ' = '
-            for key, value in config.iteritems():
+            for key, value in config.items():
                 s = s + str(key) + '=' + str(value) + ' '
         s = s.rstrip() + '\n'
     return s.rstrip()


### PR DESCRIPTION
When running ansible with python 3, this role produces the error `AttributeError: 'dict' object has no attribute 'iteritems'`. This is because in python 3, `dict.iteritems()` has become just `dict.items()`.

This change should still be compatible with python 2, since python 2 still has `dict.items()`, but it uses more memory.